### PR TITLE
Brute-force algorithm for breaking DLP

### DIFF
--- a/elliptic-curves-rs/src/breaking_dlp/brute_force.rs
+++ b/elliptic-curves-rs/src/breaking_dlp/brute_force.rs
@@ -18,7 +18,7 @@ impl<C: Curve> DiscreteLog<C> for BruteForce {
             p: &CurvePoint<C>,
             q: &CurvePoint<C>,
         ) -> (u16, C::ScalarField) {
-        if !C::is_on_curve(&p.inner) && !C::is_on_curve(&q.inner) {
+        if !C::is_on_curve(&p.inner) || !C::is_on_curve(&q.inner) {
             panic!("p or q are not on curve");
         }
 

--- a/elliptic-curves-rs/src/breaking_dlp/brute_force.rs
+++ b/elliptic-curves-rs/src/breaking_dlp/brute_force.rs
@@ -1,0 +1,40 @@
+use crate::breaking_dlp::DiscreteLog;
+use crate::core::curve::Curve;
+use crate::core::point::CurvePoint;
+
+use ark_ff::One;
+use ark_std::{
+    UniformRand,
+    rand::thread_rng,
+};
+
+pub struct BruteForce;
+
+/// For breaking discrete logarithm problem using brute-force, it takes
+/// very long time to break. Therefore, in this implementation, I limit
+/// the range of loop for observing the algorithm process.
+impl<C: Curve> DiscreteLog<C> for BruteForce {
+    fn solve(
+            p: &CurvePoint<C>,
+            q: &CurvePoint<C>,
+        ) -> (u16, C::ScalarField) {
+        if !C::is_on_curve(&p.inner) && !C::is_on_curve(&q.inner) {
+            panic!("p or q are not on curve");
+        }
+
+        let mut rng = thread_rng();
+        let start = C::ScalarField::rand(&mut rng);
+        let mut current = start;
+        let end = u16::MAX;
+
+        for steps in 0..end {
+            let result = p.mul_scalar(&current);
+            if result.inner == q.inner {
+                return (steps, current);
+            }
+
+            current += C::ScalarField::one();
+        }
+        panic!("Failed to find discrete logarithm within {} iterations", end);
+    }
+}

--- a/elliptic-curves-rs/src/breaking_dlp/mod.rs
+++ b/elliptic-curves-rs/src/breaking_dlp/mod.rs
@@ -1,3 +1,19 @@
 pub mod brute_force;
 pub mod baby_step_giant_step;
 pub mod pollards_rho;
+#[cfg(test)]
+pub mod tests;
+
+use crate::core::curve::Curve;
+use crate::core::point::CurvePoint;
+
+// 추상 메서드(=trait)만 선언하고, 하위 파일에서 구체 구현
+// 동일한 인터페이스(solve)를 갖되, 여러 알고리즘이 플러그인 형태도 들어와야.
+// 하지만, ECDH는 주어진 Curve, Field 타입에 대해 동작하는 단일 프로토콜 구현이 필요했기 떄문에
+// 제네릭 구조체 하나만으로 충분
+pub trait DiscreteLog<C: Curve> {
+    fn solve(
+        p: &CurvePoint<C>,
+        q: &CurvePoint<C>,
+    ) -> (u16, C::ScalarField); // (steps, logarithm)
+}

--- a/elliptic-curves-rs/src/breaking_dlp/tests/mod.rs
+++ b/elliptic-curves-rs/src/breaking_dlp/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod secp256k1;

--- a/elliptic-curves-rs/src/breaking_dlp/tests/secp256k1.rs
+++ b/elliptic-curves-rs/src/breaking_dlp/tests/secp256k1.rs
@@ -10,7 +10,7 @@ use crate::curves::secp256k1::secp256k1::{
 use ark_std::{UniformRand, rand::thread_rng};
 
 #[test]
-#[ignore = "It takes very long time"]
+#[ignore = "It takes a very long time"]
 fn test_brute_force_in_secp256k1() {
     let mut rng = thread_rng();
     let random_integer = FrSecp256k1::rand(&mut rng);

--- a/elliptic-curves-rs/src/breaking_dlp/tests/secp256k1.rs
+++ b/elliptic-curves-rs/src/breaking_dlp/tests/secp256k1.rs
@@ -1,0 +1,23 @@
+use crate::breaking_dlp::brute_force::BruteForce;
+use crate::breaking_dlp::DiscreteLog;
+use crate::core::curve::Curve;
+use crate::curves::secp256k1::secp256k1::{
+    Secp256k1Curve,
+    FqSecp256k1,
+    FrSecp256k1,
+};
+
+use ark_std::{UniformRand, rand::thread_rng};
+
+#[test]
+#[ignore = "It takes very long time"]
+fn test_brute_force_in_secp256k1() {
+    let mut rng = thread_rng();
+    let random_integer = FrSecp256k1::rand(&mut rng);
+
+    let g = Secp256k1Curve::generator();
+    let q = g.mul_scalar(&random_integer);
+
+    let (steps, logarithm) = BruteForce::solve(&g, &q);
+    println!("steps: {}, logarithm: {}", steps, logarithm);
+}

--- a/elliptic-curves-rs/src/core/curve.rs
+++ b/elliptic-curves-rs/src/core/curve.rs
@@ -25,6 +25,8 @@ pub trait Curve {
 
     fn order() -> <Self::ScalarField as ArkPrimeField>::BigInt;
 
+    fn is_on_curve(p: &Point<Self::BaseField>) -> bool;
+
     fn add_point(
         p: &Point<Self::BaseField>,
         q: &Point<Self::BaseField>,

--- a/elliptic-curves-rs/src/core/point.rs
+++ b/elliptic-curves-rs/src/core/point.rs
@@ -37,7 +37,7 @@ impl<F: Field> Point<F> {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct CurvePoint<C: Curve> {
     pub inner: Point<C::BaseField>,
 }

--- a/elliptic-curves-rs/src/curves/secp256k1/secp256k1.rs
+++ b/elliptic-curves-rs/src/curves/secp256k1/secp256k1.rs
@@ -93,6 +93,20 @@ impl Curve for Secp256k1Curve {
         FrSecp256k1::MODULUS
     }
 
+    fn is_on_curve(p: &Point<FqSecp256k1>) -> bool {
+        let a = Secp256k1Curve::a();
+        let b = Secp256k1Curve::b();
+        // y^2 = x^3 + ax + b
+        match (p.x(), p.y()) {
+            (Some(x), Some(y)) => {
+                let left_term = y.square();
+                let right_term = x.pow([3u64]) + a * x + b;
+                left_term == right_term
+            }
+            _ => true,
+        }
+    }
+
     fn add_point(
         p: &Point<FqSecp256k1>,
         q: &Point<FqSecp256k1>,

--- a/elliptic-curves-rs/src/curves/secp256k1/tests.rs
+++ b/elliptic-curves-rs/src/curves/secp256k1/tests.rs
@@ -85,6 +85,13 @@ fn test_basic_operations() {
 }
 
 #[test]
+fn test_is_on_curve() {
+    let g = Secp256k1Curve::generator();
+    let is_on_curve = Secp256k1Curve::is_on_curve(&g.inner);
+    assert!(is_on_curve);
+}
+
+#[test]
 fn test_point_addition() {
     let g = Secp256k1Curve::generator();
     let two_gx = FqSecp256k1::from_str(

--- a/elliptic-curves-rs/src/main.rs
+++ b/elliptic-curves-rs/src/main.rs
@@ -2,39 +2,54 @@ use elliptic_curves_rs::core::curve::Curve;
 use elliptic_curves_rs::core::field::PrimeField;
 use elliptic_curves_rs::core::point::CurvePoint;
 use elliptic_curves_rs::curves::secp256k1::secp256k1::FqSecp256k1;
+use elliptic_curves_rs::curves::secp256k1::secp256k1::FrSecp256k1;
 use elliptic_curves_rs::curves::secp256k1::secp256k1::PointSecp256k1;
 use elliptic_curves_rs::curves::secp256k1::secp256k1::Secp256k1Curve;
 
-fn main() {
-    let p = PointSecp256k1::new(
-        FqSecp256k1::from_u64(1),
-        FqSecp256k1::from_u64(2),
-    );
+use elliptic_curves_rs::breaking_dlp::brute_force::BruteForce;
+use elliptic_curves_rs::breaking_dlp::DiscreteLog;
 
-    let q = PointSecp256k1::new(
-        FqSecp256k1::from_u64(3),
-        FqSecp256k1::from_u64(4),
-    );
-    println!("{}", p);
-    println!("{}", q);
+use ark_std::{UniformRand, rand::thread_rng};
+
+fn main() {
+    // let p = PointSecp256k1::new(
+    //     FqSecp256k1::from_u64(1),
+    //     FqSecp256k1::from_u64(2),
+    // );
+
+    // let q = PointSecp256k1::new(
+    //     FqSecp256k1::from_u64(3),
+    //     FqSecp256k1::from_u64(4),
+    // );
+    // println!("{}", p);
+    // println!("{}", q);
 
     // let r1 = p.add(&q);
     // println!("{}", r1);
 
-    let a: CurvePoint<Secp256k1Curve> = PointSecp256k1::new(
-        FqSecp256k1::from_u64(1),
-        FqSecp256k1::from_u64(2),
-    );
-    let b: CurvePoint<Secp256k1Curve> = PointSecp256k1::new(
-        FqSecp256k1::from_u64(1),
-        FqSecp256k1::from_u64(2),
-    );
+    // let a: CurvePoint<Secp256k1Curve> = PointSecp256k1::new(
+    //     FqSecp256k1::from_u64(1),
+    //     FqSecp256k1::from_u64(2),
+    // );
+    // let b: CurvePoint<Secp256k1Curve> = PointSecp256k1::new(
+    //     FqSecp256k1::from_u64(1),
+    //     FqSecp256k1::from_u64(2),
+    // );
 
-    let r2 = Secp256k1Curve::add_point(&a.inner, &b.inner);
-    println!("{}", r2);
+    // let r2 = Secp256k1Curve::add_point(&a.inner, &b.inner);
+    // println!("{}", r2);
 
+    // let g = Secp256k1Curve::generator();
+    // println!("G = {}", g);
+    // println!("2G = {}", two_g);
+    
+    let mut rng = thread_rng();
+    let random_integer = FrSecp256k1::rand(&mut rng);
+    
     let g = Secp256k1Curve::generator();
-    let two_g = g.add(&g);
-    println!("G = {}", g);
-    println!("2G = {}", two_g);
+    let two = FrSecp256k1::from(2);
+    let q = g.mul_scalar(&two);
+
+    let (steps, logarithm) = BruteForce::solve(&g, &q);
+    println!("steps: {}, logarithm: {}", steps, logarithm);
 }


### PR DESCRIPTION
Introduced `DiscreteLog` trait and `BruteForce` implementation in `breaking_dlp` module. But a `brute-force` algorithm can't be used in real time because it takes a _very long_ time.

Extended `Curve` trait with `is_on_curve` function because we need to make sure that the point is above that curve.

issue: #16 