### PR TITLE
Introduce subtract

### DIFF
--- a/elliptic-curves-rs/src/core/curve.rs
+++ b/elliptic-curves-rs/src/core/curve.rs
@@ -38,4 +38,11 @@ pub trait Curve {
         p: &Point<Self::BaseField>,
         scalar: &Self::ScalarField,
     ) -> Point<Self::BaseField>;
+
+    fn subtract_point(
+        p: &Point<Self::BaseField>,
+        q: &Point<Self::BaseField>,
+    ) -> Point<Self::BaseField>;
+
+    fn negate_point(p: &Point<Self::BaseField>) -> Point<Self::BaseField>;
 }

--- a/elliptic-curves-rs/src/core/field.rs
+++ b/elliptic-curves-rs/src/core/field.rs
@@ -13,10 +13,7 @@ pub trait Field:
     fn sub(&self, other: &Self) -> Self;
     fn mul(&self, other: &Self) -> Self;
     fn inv(&self) -> Self;
-
-    fn neg(&self) -> Self {
-        Self::zero().sub(self)
-    }
+    fn neg(&self) -> Self;
 }
 
 /// Field를 상속받는 PrimeField

--- a/elliptic-curves-rs/src/core/point.rs
+++ b/elliptic-curves-rs/src/core/point.rs
@@ -56,6 +56,11 @@ impl<C: Curve> CurvePoint<C> {
         CurvePoint { inner: p }
     }
 
+    pub fn subtract(&self, other: &Self) -> Self {
+        let p = C::subtract_point(&self.inner, &other.inner);
+        CurvePoint { inner: p }
+    }
+
     pub fn double(&self) -> Self {
         let p = C::double_point(&self.inner);
         CurvePoint { inner: p }

--- a/elliptic-curves-rs/src/curves/secp256k1/secp256k1.rs
+++ b/elliptic-curves-rs/src/curves/secp256k1/secp256k1.rs
@@ -52,6 +52,10 @@ impl Field for FqSecp256k1 {
     fn inv(&self) -> Self {
         self.inverse().unwrap()
     }
+
+    fn neg(&self) -> Self {
+        -*self
+    }
 }
 
 impl PrimeField for FqSecp256k1 {
@@ -176,5 +180,23 @@ impl Curve for Secp256k1Curve {
             }
         }
         result
+    }
+
+    fn subtract_point(
+            p: &Point<FqSecp256k1>,
+            q: &Point<FqSecp256k1>,
+        ) -> Point<FqSecp256k1> {
+        let neg_q = Self::negate_point(q);
+        Self::add_point(p, &neg_q)
+    }
+
+    fn negate_point(p: &Point<FqSecp256k1>) -> Point<FqSecp256k1> {
+        match p {
+            Point::Infinity => Point::Infinity,
+            Point::Affine { x, y } => Point::Affine {
+                x: *x,
+                y: y.neg()
+            },
+        }
     }
 }

--- a/elliptic-curves-rs/src/curves/secp256k1/tests.rs
+++ b/elliptic-curves-rs/src/curves/secp256k1/tests.rs
@@ -110,6 +110,19 @@ fn test_point_addition() {
 }
 
 #[test]
+fn test_point_subtract() {
+    let g = Secp256k1Curve::generator();
+    let two_g = g.double();
+    let two_g_minus_g = two_g.subtract(&g);
+    
+    let infinity = PointSecp256k1::infinity();
+    let g_minus_g = g.subtract(&g);
+
+    assert_eq!(g, two_g_minus_g);
+    assert_eq!(infinity, g_minus_g);
+}
+
+#[test]
 fn test_scalar_mul() {
     let generator = Secp256k1Curve::generator();
     let k = FrSecp256k1::from(2u64);


### PR DESCRIPTION
Introduce `subtract`

Implemented `subtract_point` and `negate_point` in core/curve and `subtract` function in core/point.
And added a new test case for point subtraction in secp256k1 tests.

issue: None